### PR TITLE
Backwards incompatible changes to the k8s client api

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -3,11 +3,12 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
+
 	"k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/rest"
-	"net"
 )
 
 type serviceDiscovery struct {
@@ -18,7 +19,7 @@ type serviceDiscovery struct {
 }
 
 type kubernetesClient interface {
-	Core() v1core.CoreInterface
+	Core() v1core.CoreV1Interface
 }
 
 func newServiceDiscovery(host string, port string, tokenPath string, certPath string, label string, res chan<- service, errors chan<- error) (*serviceDiscovery, error) {

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/watch"
 	"k8s.io/client-go/rest"
-	"testing"
 )
 
 func TestDiscoveryServicesAddedToChannel(t *testing.T) {
@@ -55,7 +56,7 @@ func TestDiscoveryErrorAddedToChannel(t *testing.T) {
 type mockK8Client struct {
 }
 
-func (m *mockK8Client) Core() v1core.CoreInterface {
+func (m *mockK8Client) Core() v1core.CoreV1Interface {
 	return &mockCoreClient{}
 }
 


### PR DESCRIPTION
https://github.com/kubernetes/client-go/commit/ae6775eeec5cc9e96cc5cec848f589158acf7d92